### PR TITLE
Add a tooltip to each estimate card

### DIFF
--- a/src/client/modules/ui/backlogItemsForReview/backlogItemsForReview.html
+++ b/src/client/modules/ui/backlogItemsForReview/backlogItemsForReview.html
@@ -70,6 +70,7 @@
                                 data-label={estOption.name}
                                 onclick={handleSelectedOption}
                                 style={estOption.colorHexCode}
+                                title={estOption.name}
                             >
                                 {estOption.name}
                             </div>


### PR DESCRIPTION
Hi @adityanaag3 ! What do you think about adding a tooltip to the estimate cards? I often here people ask "what does SH, MH, PP, etc" mean?

Adding a `title` attribute will cause browsers to show the standard tooltip when a user hovers over the card.

We could alternatively use something like the [lightning-helptext](https://developer.salesforce.com/docs/component-library/bundle/lightning-helptext/example) web component, but I figured it was best to start simple first.

Question: What are the other properties available in `estOption`? I have used the `name` property temporarily. Is there a property that includes the full text of the estimate option, e.g. "Must have"?